### PR TITLE
Deactivate RStudio Session if rstudio-server module is not loaded for Jupyterlab

### DIFF
--- a/jupyterlab/src/index.ts
+++ b/jupyterlab/src/index.ts
@@ -27,6 +27,10 @@ var lmod = new Lmod.Lmod(
 
 var search_source = [];
 
+var is_rstudio_enable = false;
+
+var rstudio_id = "rsession:launch";
+
 function refresh_module_list() {
     Promise.all([lmod.avail(), lmod.list()])
     .then(values => {
@@ -44,6 +48,7 @@ function refresh_module_list() {
             avail_set.delete(item)
         });
 
+        is_rstudio_enable = modulelist.some(module => { return module.toLowerCase().includes("rstudio") })
         search_source = Array.from(avail_set);
         refresh_avail_list();
     });
@@ -203,6 +208,14 @@ function activate(app: JupyterLab, palette: ICommandPalette, restorer: ILayoutRe
 
 	restorer.add(widget, 'lmod-sessions');
   app.shell.addToLeftArea(widget, { rank: 1000 });
+
+  try {
+    // @ts-ignore Allow access to private variable
+    app.commands._commands[rstudio_id].isEnabled = () => {return is_rstudio_enable};
+  }
+  catch(e) {
+    //jupyterlab-rsessionproxy is not activated
+  }
 };
 
 const extension: JupyterLabPlugin<void> = {


### PR DESCRIPTION
In JupyterLab you can bind a command to a function to automatically disable it. Unfortunately, this is only accessible at the command creation in the `studio-server` extension. However, because `TypeScript` compiles in `JavaScript` and there is no private variable in `JavaScript`, it's possible to temporarily disable compiling error in TypeScript to edit a private variable. This commit edits this private variable to a boolean function who verify if the studio is loaded in `lmod`.