### PR TITLE
Fix problem with link definition in classic interface

### DIFF
--- a/jupyterlmod/static/main.js
+++ b/jupyterlmod/static/main.js
@@ -56,7 +56,7 @@ define(function(require) {
     const lmod_list_line = $([
 '<div class="list_item row">',
 '   <div class="col-md-12">',
-'       <a href="#lmod_list"/>',
+'       <a href="#lmod_list"></a>',
 '       <div class="item_buttons pull-right">',
 '           <button class="btn btn-default btn-xs" id="reload" title="Reload module"><i class="fa fa-refresh" aria-hidden="true"></i></button>',
 '           <button class="btn btn-default btn-xs" id="unload" title="Unload module"><i class="fa fa-trash-o" aria-hidden="true"></i></button>',


### PR DESCRIPTION
The <a> tag had no closing tag, but only a slash at the end. This is no longer compatible with jquery 3.5.0
which was introduced as the new jquery version for jupyter notebook >= 6.1.0.

https://jquery.com/upgrade-guide/3.5/#description-of-the-change

Fix issue #27