### PR TITLE
Reset lmod during extension start

### DIFF
--- a/lmod/__init__.py
+++ b/lmod/__init__.py
@@ -3,7 +3,7 @@ import os
 import re
 import sys
 
-from asyncio import create_subprocess_shell
+from asyncio import create_subprocess_shell, get_event_loop
 from asyncio.subprocess import PIPE
 from collections import OrderedDict
 from functools import partial, wraps
@@ -204,6 +204,7 @@ class API(object):
 
 
 _lmod = API()
+get_event_loop().run_until_complete(_lmod.reset())
 
 avail = _lmod.avail
 list = _lmod.list

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from setuptools import setup
 setup_args = dict(
     name                = 'jupyterlmod',
     packages            = ['jupyterlmod', 'lmod'],
-    version             = "3.0.0",
+    version             = "3.0.1",
     description         = "jupyterlmod: notebook server extension to interact with Lmod system",
     long_description    = "Jupyter interactive notebook server extension that allows user to select software modules to load with Lmod before launching kernels.",
     author              = "Félix-Antoine Fortin",


### PR DESCRIPTION
In our project using jupyter-lmod is combined with a system where users can select the environment modules they want prior to the launch of the server in JupyterHub. The user choices is then translated to environment variable `LMOD_SYSTEM_DEFAULT_MODULES` in the user server. However, we noticed that even though lmod CLI would respect that choice, the jupyter-lmod would not. 

We found that resetting the extension backend  by calling `_lmod.reset()` resolved our issue. Therefore, we offer to add this change in the upstream