### PR TITLE
sort list of modules case-insensitive

### DIFF
--- a/jupyterlab/src/index.ts
+++ b/jupyterlab/src/index.ts
@@ -194,7 +194,7 @@ class LmodWidget extends Widget {
     Promise.all([lmodAPI.avail(), lmodAPI.list()])
     .then(values => {
         const avail_set = new Set<string>(values[0]);
-        const modulelist = values[1].sort();
+        const modulelist = values[1];
         const html_list = modulelist.map(item => createModuleItem(item, 'Unload'));
 
         this.loadedUList.innerText = '';

--- a/lmod/__init__.py
+++ b/lmod/__init__.py
@@ -86,7 +86,7 @@ class API(object):
             string = await module("avail", *args)
             if string is not None:
                 modules = MODULE_REGEX.findall(string.strip())
-                modules.sort(key=lambda v: v.split("/")[0])
+                modules.sort(key=lambda v: v.split("/")[0].lower())
             else:
                 modules = []
             self.avail_cache = modules
@@ -98,6 +98,7 @@ class API(object):
             string = await module("list")
             if string and not string.startswith(EMPTY_LIST_STR):
                 modules = string.split()
+                modules.sort(key=lambda v: v.split("/")[0].lower())
                 self.list_cache[True] = modules
                 self.list_cache[False] = [
                     name for name in modules


### PR DESCRIPTION
The list of modules is currently sorted with the default `sort()` functions in Python and TS, which just follow the ASCII table and put all modules with capital letters before those in lower case.

We would like to have the list of modules sorted case-insensitive to be more readable by our users.

This PR also brings all sorting to the Python level, so that the lab extension does not have to deal with the list order.