### PR TITLE
inject XSRF token to all GET calls to be compliant with JupyterHub v4

### DIFF
--- a/jupyterlmod/static/lmod.js
+++ b/jupyterlmod/static/lmod.js
@@ -7,10 +7,22 @@ class Lmod {
   constructor(base_url) {
     this.url = base_url + 'lmod'
     this._xsrf = getCookie("_xsrf");
+    this._head_auth = {
+      'X-XSRFToken': this._xsrf,
+    };
+    this._head_auth_json = {
+      'Content-Type': 'application/json',
+      'X-XSRFToken': this._xsrf,
+    };
   }
 
   async avail() {
-    const response = await fetch(this.url + '/modules');
+    const response = await fetch(
+      this.url + '/modules',
+      {
+        headers: this._head_auth
+      },
+    );
     if (response.status == 200) {
       return response.json();
     }
@@ -21,7 +33,12 @@ class Lmod {
     if (include_hidden) {
       url += '?all=true';
     }
-    const response = await fetch(url);
+    const response = await fetch(
+      url,
+      {
+        headers: this._head_auth,
+      }
+    );
     if (response.status == 200) {
       return response.json();
     }
@@ -35,10 +52,7 @@ class Lmod {
       this.url,
       {
         method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          'X-XSRFToken': this._xsrf
-        },
+        headers: this._head_auth_json,
         body: JSON.stringify(data),
       }
     )
@@ -53,10 +67,7 @@ class Lmod {
       this.url + '/collections',
       {
         method: 'PATCH',
-        headers: {
-          'Content-Type': 'application/json',
-          'X-XSRFToken': this._xsrf
-        },
+        headers: this._head_auth_json,
         body: JSON.stringify(data),
       }
     )
@@ -71,10 +82,7 @@ class Lmod {
       this.url + '/collections',
       {
         method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          'X-XSRFToken': this._xsrf
-        },
+        headers: this._head_auth_json,
         body: JSON.stringify(data),
       }
     )
@@ -82,21 +90,36 @@ class Lmod {
   }
 
   async savelist() {
-    const response = await fetch(this.url + '/collections');
+    const response = await fetch(
+      this.url + '/collections',
+      {
+        headers: this._head_auth,
+      }
+    );
     if (response.status == 200) {
       return response.json();
     }
   }
 
   async show(module) {
-    const response = await fetch(this.url + '/modules/' + module);
+    const response = await fetch(
+      this.url + '/modules/' + module,
+      {
+         headers: this._head_auth,
+      }
+    );
     if (response.status == 200) {
       return response.json();
     }
   }
 
   async freeze() {
-    const response = await fetch(this.url + '?lang=python');
+    const response = await fetch(
+      this.url + '?lang=python',
+      {
+        headers: this._head_auth,
+      }
+    );
     if (response.status == 200) {
       return response.json();
     }
@@ -110,10 +133,7 @@ class Lmod {
       this.url,
       {
         method: 'DELETE',
-        headers: {
-          'Content-Type': 'application/json',
-          'X-XSRFToken': this._xsrf
-        },
+        headers: this._head_auth_json,
         body: JSON.stringify(data),
       }
     )
@@ -121,14 +141,24 @@ class Lmod {
   }
 
   async paths() {
-    const response = await fetch(this.url + '/paths');
+    const response = await fetch(
+      this.url + '/paths',
+      {
+        headers: this._head_auth,
+      }
+    );
     if (response.status == 200) {
       return response.json();
     }
   }
 
   async folders(path) {
-    const response = await fetch(this.url + '/folders/' + path);
+    const response = await fetch(
+      this.url + '/folders/' + path,
+      {
+        headers: this._head_auth,
+      }
+    );
     if (response.status == 200) {
       return response.json();
     }
@@ -143,10 +173,7 @@ class Lmod {
       this.url + '/paths',
       {
         method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          'X-XSRFToken': this._xsrf
-        },
+        headers: this._head_auth_json,
         body: JSON.stringify(data),
       }
     )
@@ -161,10 +188,7 @@ class Lmod {
       this.url + '/paths',
       {
         method: 'DELETE',
-        headers: {
-          'Content-Type': 'application/json',
-          'X-XSRFToken': this._xsrf
-        },
+        headers: this._head_auth_json,
         body: JSON.stringify(data),
       }
     )

--- a/jupyterlmod/static/main.js
+++ b/jupyterlmod/static/main.js
@@ -303,7 +303,12 @@ define(function(require) {
     }
 
     async function setup_proxy_infos() {
-        const response = await fetch(base_url + 'server-proxy/servers-info');
+        const response = await fetch(
+            base_url + 'server-proxy/servers-info',
+            {
+                headers: lmod._head_auth,
+            },
+        );
         if (!response.ok) {
             console.log('jupyter-lmod: could not communicate with jupyter-server-proxy API.');
             return;
@@ -311,7 +316,12 @@ define(function(require) {
         const data = await response.json();
 
         let launcher_pins = [];
-        const pin_response = await fetch(base_url + 'lmod/launcher-pins');
+        const pin_response = await fetch(
+            base_url + 'lmod/launcher-pins',
+            {
+                headers: lmod._head_auth,
+            },
+        );
         if (response.ok) {
           launcher_pins = (await pin_response.json()).launcher_pins;
         } else {

--- a/labextension/src/index.ts
+++ b/labextension/src/index.ts
@@ -276,7 +276,12 @@ class ILauncherProxy {
 
 async function setup_proxy_commands(app: JupyterFrontEnd, restorer: ILayoutRestorer) {
   let launcher_pins = [];
-  const pin_response = await fetch(PageConfig.getBaseUrl() + 'lmod/launcher-pins');
+  const pin_response = await fetch(
+    PageConfig.getBaseUrl() + 'lmod/launcher-pins',
+    {
+      headers: lmodAPI._head_auth,
+    },
+  );
   if (pin_response.ok) {
     const data = await pin_response.json();
     launcher_pins = data.launcher_pins.map(pin => pin.toLowerCase())


### PR DESCRIPTION
This PR fixes the internal API calls with JupyterHub 4.1.5 and is one of the fixes needed for #65.

JupyterHub 4 requires all calls to non-static resources to be authenticated through either the JupyterHub API token or a XSRF token. Otherwise we hit a similar oauth redirect loop as described in issue https://github.com/jupyterhub/jupyterhub/issues/4800. Comment https://github.com/jupyterhub/jupyterhub/issues/4800#issuecomment-2092600254 explains in detail the options to solve it.

I chose to inject the XSRF token to all GET calls, as we already do that for POST calls and it's a relatively trivial fix.