### PR TITLE
Improve UI feedback on loading/unloading modules

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -214,12 +214,21 @@ class ModuleWidget extends Widget {
     if (target.tagName == 'SPAN') {
       show_module(target.innerText);
     } else if(target.tagName == 'BUTTON') {
-      const span = event.target.closest('li').querySelector('span');
-      const item = span.innerText;
+      const parent_li = event.target.closest('li');
+      const mod_label = parent_li.querySelector('span');
+      const mod_name = mod_label.innerText;
       if(target.innerText == 'Load') {
-        await load_module(item);
+        target.innerText = 'Loading...';
+        target.style.visibility = 'visible';
+        target.style.backgroundColor = "#99b644";
+        parent_li.style.backgroundColor = "#dde6c0";
+        await load_module(mod_name);
       } else if(target.innerText == 'Unload') {
-        await moduleAPI.unload([item]);
+        target.innerText = 'Unloading...';
+        target.style.visibility = 'visible';
+        target.style.backgroundColor = "#ee8b44";
+        parent_li.style.backgroundColor = "#fad7c0";
+        await moduleAPI.unload([mod_name]);
       }
       this.update();
     }

--- a/style/index.css
+++ b/style/index.css
@@ -115,12 +115,12 @@
 }
 
 .jp-Module-item .jp-Module-itemButton {
+    visibility: hidden;
     border-radius: 0px;
 }
 
-.jp-Module-item:not(:hover) .jp-Module-itemButton {
-    visibility: hidden;
-    /* display: none; */
+.jp-Module-item:hover .jp-Module-itemButton {
+    visibility: visible;
 }
 
 .jp-Module-itemLabel {
@@ -174,6 +174,11 @@
     line-height: inherit;
     background-color: lightgrey;
     border-radius: 5px 5px 5px 5px;
+    cursor: pointer;
+}
+
+.jp-Module-itemButton.jp-mod-styled:hover {
+    background-color: rgb(230, 209, 102);
 }
 
 div.iframe-widget {


### PR DESCRIPTION
Currently clicking the _Load/Unload_ button does not cause any change on the UI. So while modules load/unload it might seem that nothing was triggered by the click.

This PR makes a few style changes to improve the UI feedback on loading/unloading modules:
* use pointer cursor on _Load/Unload_ button
* add hover color to _Load/Unload_ button
* on click, change _Load/Unload_ button to a _Loading/Unloading_ state (with different label and color)

Demo:
[jupyter-lmod-ui-feedback.webm](https://github.com/cmd-ntrf/jupyter-lmod/assets/4973794/10dbb21f-b82f-48bf-b8dd-4366bae65935)

I'm targeting the `jupyterlab4` branch, as that is the active development now. But this PR is not really related to the changes for jupyterlab v4 in #70 .