### PR TITLE
Fix corutine not always resolving in decorator

### DIFF
--- a/module/__init__.py
+++ b/module/__init__.py
@@ -3,7 +3,6 @@
 import os
 import re
 import sys
-
 from asyncio import create_subprocess_shell
 from asyncio.subprocess import PIPE
 from collections import OrderedDict
@@ -83,13 +82,13 @@ def update_sys_path(env_var, postfix=""):
     """
     def decorator(function):
         @wraps(function)
-        def wrapper(*args, **kargs):
+        async def wrapper(*args, **kargs):
             if env_var in os.environ:
                 orig_paths = os.environ[env_var].split(os.pathsep)
                 orig_paths = [os.path.join(path, postfix) for path in orig_paths]
             else:
                 orig_paths = []
-            output = function(*args, **kargs)
+            output = await function(*args, **kargs)
             if env_var in os.environ:
                 new_paths = os.environ[env_var].split(os.pathsep)
                 new_paths = [os.path.join(path, postfix) for path in new_paths]


### PR DESCRIPTION
The `update_sys_path` decorator is always used to decorate `async` functions which leads `output = function(*args, **kargs)` to be a non-awaited co-rutine.

I've observed that this can lead to `new_paths = os.environ[env_var].split(os.pathsep)` to not contain the expected paths from the module load, and hence `sys.path` not being updated